### PR TITLE
[PR-1] Create the Accounts context with Employee resource

### DIFF
--- a/lib/talent_base/accounts.ex
+++ b/lib/talent_base/accounts.ex
@@ -1,0 +1,104 @@
+defmodule TalentBase.Accounts do
+  @moduledoc """
+  The Accounts context.
+  """
+
+  import Ecto.Query, warn: false
+  alias TalentBase.Repo
+
+  alias TalentBase.Accounts.Employee
+
+  @doc """
+  Returns the list of employees.
+
+  ## Examples
+
+      iex> list_employees()
+      [%Employee{}, ...]
+
+  """
+  def list_employees do
+    Repo.all(Employee)
+  end
+
+  @doc """
+  Gets a single employee.
+
+  Raises `Ecto.NoResultsError` if the Employee does not exist.
+
+  ## Examples
+
+      iex> get_employee!(123)
+      %Employee{}
+
+      iex> get_employee!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_employee!(id), do: Repo.get!(Employee, id)
+
+  @doc """
+  Creates a employee.
+
+  ## Examples
+
+      iex> create_employee(%{field: value})
+      {:ok, %Employee{}}
+
+      iex> create_employee(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_employee(attrs \\ %{}) do
+    %Employee{}
+    |> Employee.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a employee.
+
+  ## Examples
+
+      iex> update_employee(employee, %{field: new_value})
+      {:ok, %Employee{}}
+
+      iex> update_employee(employee, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_employee(%Employee{} = employee, attrs) do
+    employee
+    |> Employee.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a employee.
+
+  ## Examples
+
+      iex> delete_employee(employee)
+      {:ok, %Employee{}}
+
+      iex> delete_employee(employee)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_employee(%Employee{} = employee) do
+    Repo.delete(employee)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking employee changes.
+
+  ## Examples
+
+      iex> change_employee(employee)
+      %Ecto.Changeset{data: %Employee{}}
+
+  """
+  def change_employee(%Employee{} = employee, attrs \\ %{}) do
+    Employee.changeset(employee, attrs)
+  end
+end

--- a/lib/talent_base/accounts/employee.ex
+++ b/lib/talent_base/accounts/employee.ex
@@ -1,0 +1,18 @@
+defmodule TalentBase.Accounts.Employee do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "employees" do
+    field :name, :string
+    field :age, :integer
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(employee, attrs) do
+    employee
+    |> cast(attrs, [:name, :age])
+    |> validate_required([:name, :age])
+  end
+end

--- a/priv/repo/migrations/20240822033715_create_employees.exs
+++ b/priv/repo/migrations/20240822033715_create_employees.exs
@@ -1,0 +1,12 @@
+defmodule TalentBase.Repo.Migrations.CreateEmployees do
+  use Ecto.Migration
+
+  def change do
+    create table(:employees) do
+      add :name, :string
+      add :age, :integer
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule TalentBase.AccountsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `TalentBase.Accounts` context.
+  """
+
+  @doc """
+  Generate a employee.
+  """
+  def employee_fixture(attrs \\ %{}) do
+    {:ok, employee} =
+      attrs
+      |> Enum.into(%{
+        age: 42,
+        name: "some name"
+      })
+      |> TalentBase.Accounts.create_employee()
+
+    employee
+  end
+end

--- a/test/talent_base/accounts_test.exs
+++ b/test/talent_base/accounts_test.exs
@@ -1,0 +1,61 @@
+defmodule TalentBase.AccountsTest do
+  use TalentBase.DataCase
+
+  alias TalentBase.Accounts
+
+  describe "employees" do
+    alias TalentBase.Accounts.Employee
+
+    import TalentBase.AccountsFixtures
+
+    @invalid_attrs %{name: nil, age: nil}
+
+    test "list_employees/0 returns all employees" do
+      employee = employee_fixture()
+      assert Accounts.list_employees() == [employee]
+    end
+
+    test "get_employee!/1 returns the employee with given id" do
+      employee = employee_fixture()
+      assert Accounts.get_employee!(employee.id) == employee
+    end
+
+    test "create_employee/1 with valid data creates a employee" do
+      valid_attrs = %{name: "some name", age: 42}
+
+      assert {:ok, %Employee{} = employee} = Accounts.create_employee(valid_attrs)
+      assert employee.name == "some name"
+      assert employee.age == 42
+    end
+
+    test "create_employee/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_employee(@invalid_attrs)
+    end
+
+    test "update_employee/2 with valid data updates the employee" do
+      employee = employee_fixture()
+      update_attrs = %{name: "some updated name", age: 43}
+
+      assert {:ok, %Employee{} = employee} = Accounts.update_employee(employee, update_attrs)
+      assert employee.name == "some updated name"
+      assert employee.age == 43
+    end
+
+    test "update_employee/2 with invalid data returns error changeset" do
+      employee = employee_fixture()
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_employee(employee, @invalid_attrs)
+      assert employee == Accounts.get_employee!(employee.id)
+    end
+
+    test "delete_employee/1 deletes the employee" do
+      employee = employee_fixture()
+      assert {:ok, %Employee{}} = Accounts.delete_employee(employee)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_employee!(employee.id) end
+    end
+
+    test "change_employee/1 returns a employee changeset" do
+      employee = employee_fixture()
+      assert %Ecto.Changeset{} = Accounts.change_employee(employee)
+    end
+  end
+end


### PR DESCRIPTION
### Changes

- Create the Accounts context with Employee resource by running `mix phx.gen.context Accounts Employee employees name:string age:integer`