### PR TITLE
[PR-2] Add employee history resource to the Accounts context

### DIFF
--- a/lib/talent_base/accounts.ex
+++ b/lib/talent_base/accounts.ex
@@ -101,4 +101,100 @@ defmodule TalentBase.Accounts do
   def change_employee(%Employee{} = employee, attrs \\ %{}) do
     Employee.changeset(employee, attrs)
   end
+
+  alias TalentBase.Accounts.EmployeeHistory
+
+  @doc """
+  Returns the list of employees_history.
+
+  ## Examples
+
+      iex> list_employees_history()
+      [%EmployeeHistory{}, ...]
+
+  """
+  def list_employees_history do
+    Repo.all(EmployeeHistory)
+  end
+
+  @doc """
+  Gets a single employee_history.
+
+  Raises `Ecto.NoResultsError` if the Employee history does not exist.
+
+  ## Examples
+
+      iex> get_employee_history!(123)
+      %EmployeeHistory{}
+
+      iex> get_employee_history!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_employee_history!(id), do: Repo.get!(EmployeeHistory, id)
+
+  @doc """
+  Creates a employee_history.
+
+  ## Examples
+
+      iex> create_employee_history(%{field: value})
+      {:ok, %EmployeeHistory{}}
+
+      iex> create_employee_history(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_employee_history(attrs \\ %{}) do
+    %EmployeeHistory{}
+    |> EmployeeHistory.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a employee_history.
+
+  ## Examples
+
+      iex> update_employee_history(employee_history, %{field: new_value})
+      {:ok, %EmployeeHistory{}}
+
+      iex> update_employee_history(employee_history, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_employee_history(%EmployeeHistory{} = employee_history, attrs) do
+    employee_history
+    |> EmployeeHistory.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a employee_history.
+
+  ## Examples
+
+      iex> delete_employee_history(employee_history)
+      {:ok, %EmployeeHistory{}}
+
+      iex> delete_employee_history(employee_history)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_employee_history(%EmployeeHistory{} = employee_history) do
+    Repo.delete(employee_history)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking employee_history changes.
+
+  ## Examples
+
+      iex> change_employee_history(employee_history)
+      %Ecto.Changeset{data: %EmployeeHistory{}}
+
+  """
+  def change_employee_history(%EmployeeHistory{} = employee_history, attrs \\ %{}) do
+    EmployeeHistory.changeset(employee_history, attrs)
+  end
 end

--- a/lib/talent_base/accounts/employee_history.ex
+++ b/lib/talent_base/accounts/employee_history.ex
@@ -1,0 +1,21 @@
+defmodule TalentBase.Accounts.EmployeeHistory do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "employees_history" do
+    field :employee_id, :binary
+    field :supervisor_id, :binary
+    field :present, :boolean, default: false
+    field :start_date, :utc_datetime
+    field :end_date, :utc_datetime
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(employee_history, attrs) do
+    employee_history
+    |> cast(attrs, [:employee_id, :supervisor_id, :present, :start_date, :end_date])
+    |> validate_required([:employee_id, :supervisor_id, :present, :start_date, :end_date])
+  end
+end

--- a/priv/repo/migrations/20240822042621_create_employees_history.exs
+++ b/priv/repo/migrations/20240822042621_create_employees_history.exs
@@ -1,0 +1,15 @@
+defmodule TalentBase.Repo.Migrations.CreateEmployeesHistory do
+  use Ecto.Migration
+
+  def change do
+    create table(:employees_history) do
+      add :employee_id, :binary
+      add :supervisor_id, :binary
+      add :present, :boolean, default: false, null: false
+      add :start_date, :utc_datetime
+      add :end_date, :utc_datetime
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -18,4 +18,22 @@ defmodule TalentBase.AccountsFixtures do
 
     employee
   end
+
+  @doc """
+  Generate a employee_history.
+  """
+  def employee_history_fixture(attrs \\ %{}) do
+    {:ok, employee_history} =
+      attrs
+      |> Enum.into(%{
+        employee_id: "some employee_id",
+        end_date: ~U[2024-08-21 04:25:00Z],
+        present: true,
+        start_date: ~U[2024-08-21 04:25:00Z],
+        supervisor_id: "some supervisor_id"
+      })
+      |> TalentBase.Accounts.create_employee_history()
+
+    employee_history
+  end
 end

--- a/test/talent_base/accounts_test.exs
+++ b/test/talent_base/accounts_test.exs
@@ -58,4 +58,66 @@ defmodule TalentBase.AccountsTest do
       assert %Ecto.Changeset{} = Accounts.change_employee(employee)
     end
   end
+
+  describe "employees_history" do
+    alias TalentBase.Accounts.EmployeeHistory
+
+    import TalentBase.AccountsFixtures
+
+    @invalid_attrs %{employee_id: nil, supervisor_id: nil, present: nil, start_date: nil, end_date: nil}
+
+    test "list_employees_history/0 returns all employees_history" do
+      employee_history = employee_history_fixture()
+      assert Accounts.list_employees_history() == [employee_history]
+    end
+
+    test "get_employee_history!/1 returns the employee_history with given id" do
+      employee_history = employee_history_fixture()
+      assert Accounts.get_employee_history!(employee_history.id) == employee_history
+    end
+
+    test "create_employee_history/1 with valid data creates a employee_history" do
+      valid_attrs = %{employee_id: "some employee_id", supervisor_id: "some supervisor_id", present: true, start_date: ~U[2024-08-21 04:25:00Z], end_date: ~U[2024-08-21 04:25:00Z]}
+
+      assert {:ok, %EmployeeHistory{} = employee_history} = Accounts.create_employee_history(valid_attrs)
+      assert employee_history.employee_id == "some employee_id"
+      assert employee_history.supervisor_id == "some supervisor_id"
+      assert employee_history.present == true
+      assert employee_history.start_date == ~U[2024-08-21 04:25:00Z]
+      assert employee_history.end_date == ~U[2024-08-21 04:25:00Z]
+    end
+
+    test "create_employee_history/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_employee_history(@invalid_attrs)
+    end
+
+    test "update_employee_history/2 with valid data updates the employee_history" do
+      employee_history = employee_history_fixture()
+      update_attrs = %{employee_id: "some updated employee_id", supervisor_id: "some updated supervisor_id", present: false, start_date: ~U[2024-08-22 04:25:00Z], end_date: ~U[2024-08-22 04:25:00Z]}
+
+      assert {:ok, %EmployeeHistory{} = employee_history} = Accounts.update_employee_history(employee_history, update_attrs)
+      assert employee_history.employee_id == "some updated employee_id"
+      assert employee_history.supervisor_id == "some updated supervisor_id"
+      assert employee_history.present == false
+      assert employee_history.start_date == ~U[2024-08-22 04:25:00Z]
+      assert employee_history.end_date == ~U[2024-08-22 04:25:00Z]
+    end
+
+    test "update_employee_history/2 with invalid data returns error changeset" do
+      employee_history = employee_history_fixture()
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_employee_history(employee_history, @invalid_attrs)
+      assert employee_history == Accounts.get_employee_history!(employee_history.id)
+    end
+
+    test "delete_employee_history/1 deletes the employee_history" do
+      employee_history = employee_history_fixture()
+      assert {:ok, %EmployeeHistory{}} = Accounts.delete_employee_history(employee_history)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_employee_history!(employee_history.id) end
+    end
+
+    test "change_employee_history/1 returns a employee_history changeset" do
+      employee_history = employee_history_fixture()
+      assert %Ecto.Changeset{} = Accounts.change_employee_history(employee_history)
+    end
+  end
 end


### PR DESCRIPTION
### Changes

- Add employee history resource to the Accounts context by running ` mix phx.gen.context Accounts EmployeeHistory employees_history employee_id:binary supervisor_id:binary present:boolean start_date:utc_datetime end_date:utc_datetime`